### PR TITLE
Transition_Windows

### DIFF
--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -369,23 +369,21 @@ void MxTransitionManager::Transition_Windows()
   if (res == DD_OK) {
     SubmitCopyRect(&ddsd);
 
-    MxS32 widthInPixels = ddsd.lPitch / 8;
+    MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
+    MxS32 bytesPerLine = bytesPerPixel * 640;
 
     MxU8 *line = (MxU8 *) ddsd.lpSurface + m_animationTimer * ddsd.lPitch;
-    memset(line, 0, widthInPixels * 640);
+    memset(line, 0, bytesPerLine);
 
-    MxS32 count = m_animationTimer + 1;
-    while (count < 480 - m_animationTimer) {
+    for (MxS32 i = m_animationTimer + 1; i < 480 - m_animationTimer; i++) {
       line += ddsd.lPitch;
 
-      memset(line + m_animationTimer * widthInPixels, 0, ddsd.lPitch / 8);
-      memset(line + (640 - 1 - m_animationTimer) * widthInPixels, 0, ddsd.lPitch / 8);
-      
-      count++;
+      memset(line + m_animationTimer * bytesPerPixel, 0, bytesPerLine);
+      memset(line + 640 + (-1 - m_animationTimer) * bytesPerPixel, 0, bytesPerLine);
     }
 
     line += ddsd.lPitch;
-    memset(line, 0, widthInPixels * 640);
+    memset(line, 0, bytesPerLine);
 
     SetupCopyRect(&ddsd);
     m_ddSurface->Unlock(ddsd.lpSurface);


### PR DESCRIPTION
I took a stab at this and got (I think) a little closer, except for the usual compiler entropy. See what you think.

It would help to know what this is _supposed_ to do. This transition isn't used, so it's entirely likely that it's just got some bugs. Maybe the pointer math works better in 256 color mode?

![lego island windows](https://github.com/Ramen2X/isle/assets/6954746/f19498ea-0cf7-4b20-89c0-d7258cef6f85)
